### PR TITLE
Unbreak pkg-config detection of python.

### DIFF
--- a/build.scm
+++ b/build.scm
@@ -22,7 +22,7 @@
 (define (python-pkg-config-test package)
   (and-let* ((cflags (pkg-config:cflags package))
 	     (libs (pkg-config:libs package)))
-    (python-test ("<python.h>" cflags libs))))
+    (python-test ("<Python.h>" (string-join cflags " " 'infix) (string-join libs " " 'infix)))))
 
 (define cpp+ld-options
   (let ((cflags (get-environment-variable "PYTHON_CFLAGS"))


### PR DESCRIPTION
pkg-config:cflags and pkg-config:libs return lists, not strings.
Also it looks like when I added the pkg-config support,
I misspelled Python.h.
